### PR TITLE
Fix import regressions after orchestrator refactor

### DIFF
--- a/src/models/run.py
+++ b/src/models/run.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import AnyHttpUrl, BaseModel, Field
 
-from ..schema import RunStatus
+from ..db.schema import RunStatus
 
 
 class StartRunRequest(BaseModel):

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,8 +1,34 @@
 """Service layer for the asynchronous orchestrator."""
 
-from .callbacks import AsyncCallbackManager
-from ..db.db_connector import AsyncDBConnector
-from .workflow import AsyncOrchestrator
-from .run_manager import RunManager
+from __future__ import annotations
 
-__all__ = ["AsyncCallbackManager", "AsyncDBConnector", "AsyncOrchestrator", "RunManager"]
+from typing import TYPE_CHECKING, Any
+
+__all__ = ("AsyncCallbackManager", "AsyncDBConnector", "AsyncOrchestrator", "RunManager")
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - runtime convenience import
+    if name == "AsyncCallbackManager":
+        from .callbacks import AsyncCallbackManager as _AsyncCallbackManager
+
+        return _AsyncCallbackManager
+    if name == "AsyncDBConnector":
+        from ..db.db_connector import AsyncDBConnector as _AsyncDBConnector
+
+        return _AsyncDBConnector
+    if name == "AsyncOrchestrator":
+        from .workflow import AsyncOrchestrator as _AsyncOrchestrator
+
+        return _AsyncOrchestrator
+    if name == "RunManager":
+        from .run_manager import RunManager as _RunManager
+
+        return _RunManager
+    raise AttributeError(f"module 'services' has no attribute {name!r}")
+
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
+    from .callbacks import AsyncCallbackManager as AsyncCallbackManager
+    from ..db.db_connector import AsyncDBConnector as AsyncDBConnector
+    from .workflow import AsyncOrchestrator as AsyncOrchestrator
+    from .run_manager import RunManager as RunManager

--- a/src/services/orchestrator/agent.py
+++ b/src/services/orchestrator/agent.py
@@ -3,18 +3,21 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
-from ..services import AsyncCallbackManager, AsyncDBConnector, AsyncOrchestrator
-from ..services.workflow import celery_app
+from ..workflow import AsyncOrchestrator, celery_app
+
+if TYPE_CHECKING:  # pragma: no cover - only used for type checkers
+    from ..callbacks import AsyncCallbackManager
+    from ...db.db_connector import AsyncDBConnector
 from .utils.state import OrchestratorOutcome
 
 
 async def async_run_orchestrator(
     doc_path: str,
     *,
-    callbacks: Optional[AsyncCallbackManager] = None,
-    db: Optional[AsyncDBConnector] = None,
+    callbacks: Optional["AsyncCallbackManager"] = None,
+    db: Optional["AsyncDBConnector"] = None,
     run_id: Optional[str] = None,
 ) -> OrchestratorOutcome:
     orchestrator = AsyncOrchestrator(callbacks=callbacks, db=db)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from orchestrator.agent import run_orchestrator
+from services.orchestrator.agent import run_orchestrator
 
 
 @pytest.mark.parametrize("doc_path", ["examples/sample_docs/web_user_stories.md"])


### PR DESCRIPTION
## Summary
- update the run model to import `RunStatus` from the new database schema location
- provide lazy exports in `services.__init__` so importing `services.orchestrator.agent` no longer raises
- update the orchestrator service agent and tests to use the refactored module path

## Testing
- pytest *(fails: ImportError: attempted relative import beyond top-level package in services.workflow)*

------
https://chatgpt.com/codex/tasks/task_e_68e60e3e8aec832abd23e7469b79a651